### PR TITLE
Display only active shipping methods 

### DIFF
--- a/src/@next/components/organisms/CheckoutShipping/CheckoutShipping.tsx
+++ b/src/@next/components/organisms/CheckoutShipping/CheckoutShipping.tsx
@@ -51,9 +51,11 @@ const CheckoutShipping: React.FC<IProps> = ({
               ref={formRef}
               onSubmit={handleSubmit}
             >
-              {shippingMethods.map(({ id, name, price }, index) => {
+              {shippingMethods.map(({ id, name, price, active }) => {
                 const checked =
                   !!values.shippingMethod && values.shippingMethod === id;
+
+                if (!active) return null;
 
                 return (
                   <S.Tile

--- a/src/@next/components/organisms/CheckoutShipping/fixtures.ts
+++ b/src/@next/components/organisms/CheckoutShipping/fixtures.ts
@@ -8,6 +8,8 @@ const shippingMethods: IShippingMethod[] = [
       amount: 32,
       currency: "USD",
     },
+    active: true,
+    message: "",
   },
   {
     id: "2",
@@ -16,6 +18,8 @@ const shippingMethods: IShippingMethod[] = [
       amount: 64,
       currency: "USD",
     },
+    active: true,
+    message: "",
   },
 ];
 

--- a/src/@next/components/organisms/CheckoutShipping/types.ts
+++ b/src/@next/components/organisms/CheckoutShipping/types.ts
@@ -18,6 +18,8 @@ export interface IShippingMethod {
   id: string;
   name: string;
   price: IShippingMethodPrice | null;
+  active: boolean;
+  message: string | null;
 }
 
 export interface IProps {

--- a/src/@next/pages/CheckoutPage/subpages/CheckoutShippingSubpage.tsx
+++ b/src/@next/pages/CheckoutPage/subpages/CheckoutShippingSubpage.tsx
@@ -25,13 +25,7 @@ const CheckoutShippingSubpageWithRef: RefForwardingComponent<
 
   const [errors, setErrors] = useState<IFormError[]>([]);
 
-  const {
-    checkout,
-    availableShippingMethods,
-    setShippingMethod,
-  } = useCheckout();
-
-  const shippingMethods = availableShippingMethods || [];
+  const { checkout, shippingMethods, setShippingMethod } = useCheckout();
 
   useImperativeHandle(ref, () => () => {
     checkoutShippingFormRef.current?.dispatchEvent(
@@ -54,7 +48,7 @@ const CheckoutShippingSubpageWithRef: RefForwardingComponent<
 
   return (
     <CheckoutShipping
-      shippingMethods={shippingMethods}
+      shippingMethods={shippingMethods || []}
       selectedShippingMethodId={checkout?.shippingMethod?.id}
       errors={errors}
       selectShippingMethod={handleSetShippingMethod}


### PR DESCRIPTION
I want to merge this change because I changed that only active shipping methods will be displayed ([SALEOR-4370](https://app.clickup.com/t/2549495/SALEOR-4370))

#### PR intended to be tested with API branch:

https://github.com/SaleorIntegrations/saleor/tree/feature/exclude-shipping-methods-3-0
https://github.com/SaleorIntegrations/saleor-sdk/tree/refactor/shipping-methods

<!-- Please mention all relevant issue numbers. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/
